### PR TITLE
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=832265

### DIFF
--- a/lmove.c
+++ b/lmove.c
@@ -669,8 +669,10 @@ int do_lockfile(PMaster master, int option) {
 		sprintf(lockfile, "%s/%s", master->basedir, N_LMOVE_LOCKFILE);
 		if((f_lock = fopen(lockfile, "r")) != NULL) {
 			/* okay, let's try and see if this sucker is truly alive */
-			fscanf(f_lock, "%ld", (long *) &pid);
+			long tmp = 0; 
+			fscanf(f_lock, "%ld", &tmp);
 			fclose(f_lock);
+			pid = (pid_t)tmp;
 			if(pid <= 0) {
 				error_log(ERRLOG_REPORT,  lmove_phrases[14], lockfile, NULL);
 				retval = RETVAL_ERROR;

--- a/suckutils.c
+++ b/suckutils.c
@@ -177,8 +177,10 @@ int do_lockfile(PMaster master) {
 	lockfile = full_path(FP_GET, FP_TMPDIR, N_LOCKFILE);
 	if((f_lock = fopen(lockfile, "r")) != NULL) {
 		/* okay, let's try and see if this sucker is truly alive */
-		fscanf(f_lock, "%ld", (long *) &pid);
+		long tmp = 0; 
+		fscanf(f_lock, "%ld", &tmp);
 		fclose(f_lock);
+		pid = (pid_t)tmp;
 		if(pid <= 0) {
 			error_log(ERRLOG_REPORT,  sucku_phrases[2], lockfile, NULL);
 			retval = RETVAL_ERROR;


### PR DESCRIPTION
The switch to using -fstack-protector-strong in stretch has exposed a
stack-smashing bug.

The problem affects 64-bit platforms, as the code is assuming
sizeof(pid_t) == sizeof(long), yet on x86_64:

sizeof(pid_t) == 4
sizeof(long) == 8

The relevant code is in suckutils.c, do_lockfile():

int do_lockfile(PMaster master) {
...
    pid_t pid;
...
        fscanf(f_lock, "%ld", (long *) &pid);
...
}

This writes an 8-byte long to the location of the 4-byte pid variable,
smashing 4 bytes of the stack.

I doubt this is usefully exploitable (with the stack protector enabled,
it's only overwriting the canary), but it does mean a stale lockfile
causes suck to crash (but helpfully, the lockfile is unlinked before the
crash, so the next run will be successful).

This is obviously an upstream bug, but unfortunately there no longer
appears to be an upstream...