### PR TITLE
if no host is provided to `connect_to_nntphost` return early. 

### DIFF
--- a/both.c
+++ b/both.c
@@ -162,6 +162,11 @@ int connect_to_nntphost(const char *host, char * name, size_t namelen, FILE *msg
 	struct addrinfo * ai;
 	char buffer[60]; // if not given by caller. NI_MAXHOST would be better, but that's ok as well.
 
+	if (host == NULL) {
+		error_log(ERRLOG_REPORT, both_phrases[0], NULL);
+		return sockfd;
+	}
+
 #ifdef HAVE_LIBSSL
 	SSL *ssl_struct = NULL;
 	SSL_CTX *test1 = NULL;


### PR DESCRIPTION
 Previously, it would `strdup(NULL)` which is undefined and can cause a SIGSEGV.

This fixes some, if not all, of the Mayhem bugs [here](https://bugs.debian.org/cgi-bin/pkgreport.cgi?pkg=suck;dist=unstable)