### PR TITLE
chkhistory_db.c: Add missing <string.h> include for strlen

### DIFF
--- a/chkhistory_db.c
+++ b/chkhistory_db.c
@@ -5,6 +5,7 @@
 /* be used. */
 
 #include <stdio.h>
+#include <string.h>
 
 #include "suck_config.h"
 #include "suck.h"


### PR DESCRIPTION
This fixes compilation with clang-16+ which turned -Wimplicit-function-declaration into errors by default.

Bug: https://bugs.gentoo.org/875035
